### PR TITLE
Add Loader Component and Overview Map

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -155,10 +155,10 @@ export default props => {
           <button onClick={window.print}>Print Report</button>
         </div>
       </ProgressBar>
-      <CoverPage aoiDescription={props.description} {...reportTextMap} />
-      <SummaryPage {...reportTextMap} />
       <HazardMap aoi={props.polygon} queriesWithResults={queriesWithResults}>
-      {Object.keys(groupToHazardMap).map(groupName => (
+        <CoverPage aoiDescription={props.description} {...reportTextMap} />
+        <SummaryPage {...reportTextMap} />
+        {Object.keys(groupToHazardMap).map(groupName => (
           <Group key={groupName} name={groupName} text={groupToTextMap[groupName]}>
             {hazardIntroText && hazardReferences && hazardToUnitMap && groupToHazardMap[groupName].map(hazardCode => {
               const intro = hazardIntroText.filter(x => x.Hazard === hazardCode)[0];
@@ -175,13 +175,13 @@ export default props => {
                 })}
           </Group>
         ))}
+        <OtherDataPage {...otherDataMap['Lidar Elevation Data']}>
+          {"<lidar-specific stuff>"}
+        </OtherDataPage>
+        <OtherDataPage {...otherDataMap['Aerial Photography and Imagery']}>
+          {"<imagery-specific stuff>"}
+        </OtherDataPage>
       </HazardMap>
-      <OtherDataPage {...otherDataMap['Lidar Elevation Data']}>
-        {"<lidar-specific stuff>"}
-      </OtherDataPage>
-      <OtherDataPage {...otherDataMap['Aerial Photography and Imagery']}>
-        {"<imagery-specific stuff>"}
-      </OtherDataPage>
       <div className="header page-break">
         <h1>OTHER GEOLOGIC HAZARD RESOURCES</h1>
         <p dangerouslySetInnerHTML={{__html: reportTextMap.OtherResources}}

--- a/src/config.js
+++ b/src/config.js
@@ -1,5 +1,6 @@
 const baseUrl = 'https://services.arcgis.com/ZzrwjTRez6FJiOq4/arcgis/rest/services';
 export default {
+  overviewMapKey: 'overview-map',
   notProd: process.env.REACT_APP_ENVIRONMENT !== 'production',
   urls: {
     baseUrl,

--- a/src/esriModules.js
+++ b/src/esriModules.js
@@ -18,7 +18,10 @@ export default async () => {
     Graphic,
     watchUtils,
     symbolUtils
-  ] = await loadModules(requires, { css: true });
+  ] = await loadModules(requires, {
+    version: '4.13',
+    css: true
+  });
 
   return {
     WebMap, MapView, Polygon, Graphic, watchUtils, symbolUtils

--- a/src/reportParts/CoverPage.js
+++ b/src/reportParts/CoverPage.js
@@ -1,10 +1,15 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import ugsLogo from '../images/ugs-logo.jpg';
 import config from '../config';
 import './CoverPage.scss';
+import { HazardMapContext } from './HazardMap';
+import Loader from './Loader';
 
 
 export default ({ aoiDescription, aoi, Introduction, Disclaimer }) => {
+  const mapContext = useContext(HazardMapContext);
+  const visualAssets = mapContext.visualAssets[config.overviewMapKey];
+
   return (
     <div className="cover-page">
       <div className="header">
@@ -15,7 +20,8 @@ export default ({ aoiDescription, aoi, Introduction, Disclaimer }) => {
       </div>
       <p dangerouslySetInnerHTML={{ __html: Introduction }}
         title={config.notProd && 'ReportTextTable.Text(Introduction)'}></p>
-      {'<map>'}
+      { visualAssets ? <img src={visualAssets.mapImage}
+        alt="map" className="hazard-map-image" /> : <Loader /> }
       <p dangerouslySetInnerHTML={{ __html: Disclaimer }}
         title={config.notProd && 'ReportTextTable.Text(Disclaimer)'}></p>
     </div>

--- a/src/reportParts/Hazard.js
+++ b/src/reportParts/Hazard.js
@@ -1,6 +1,7 @@
 import React, { useContext } from 'react';
 import { HazardMapContext } from './HazardMap';
 import config from '../config';
+import Loader from './Loader';
 
 
 export default props => {
@@ -13,8 +14,8 @@ export default props => {
     <div className="page-break">
       <h2 title={config.notProd && 'HazardUnitTextTable.HazardName (from first unit)'}>{props.name}</h2>
       <p dangerouslySetInnerHTML={{ __html: props.introText }} title={config.notProd && 'HazardIntroTextTable.Text'}></p>
-      { visualAssets && <img src={visualAssets.mapImage}
-        alt="map" style={{width: '100%', minHeight: '200px'}} /> }
+      { visualAssets ? <img src={visualAssets.mapImage}
+        alt="map" style={{width: '100%', minHeight: '200px'}} /> : <Loader /> }
       {props.children}
     </div>
   );

--- a/src/reportParts/Hazard.js
+++ b/src/reportParts/Hazard.js
@@ -15,7 +15,7 @@ export default props => {
       <h2 title={config.notProd && 'HazardUnitTextTable.HazardName (from first unit)'}>{props.name}</h2>
       <p dangerouslySetInnerHTML={{ __html: props.introText }} title={config.notProd && 'HazardIntroTextTable.Text'}></p>
       { visualAssets ? <img src={visualAssets.mapImage}
-        alt="map" style={{width: '100%', minHeight: '200px'}} /> : <Loader /> }
+        alt="map" className="hazard-map-image" /> : <Loader /> }
       {props.children}
     </div>
   );

--- a/src/reportParts/HazardMap.js
+++ b/src/reportParts/HazardMap.js
@@ -2,6 +2,7 @@ import React, { useContext, useState, useEffect, createContext } from 'react';
 import config from '../config';
 import getModules from '../esriModules';
 import { ProgressContext } from '../App';
+import './HazardMap.scss';
 
 
 export const HazardMapContext = createContext({
@@ -68,10 +69,15 @@ export default props => {
 
       registerProgressItem(getProgressId(url));
     }
+
+    registerProgressItem(getProgressId(config.overviewMapKey));
+
   }, [props.queriesWithResults, registerProgressItem]);
 
   useEffect(() => {
     const getScreenshots = async () => {
+      console.log('getScreenshots', props.queriesWithResults);
+
       const newScreenshots = {};
       for (let index = 0; index < props.queriesWithResults.length; index++) {
         const [url, hazardCode] = props.queriesWithResults[index];
@@ -80,6 +86,11 @@ export default props => {
 
         newScreenshots[hazardCode] = {mapImage: screenshot.dataUrl, renderer};
       }
+
+      // generate overview map
+      const { screenshot } = await getScreenshot();
+      newScreenshots[config.overviewMapKey] = { mapImage: screenshot.dataUrl };
+      setProgressItemAsComplete(getProgressId(config.overviewMapKey));
 
       setVisualAssets(newScreenshots);
     };
@@ -103,7 +114,7 @@ export default props => {
 };
 
 const getScreenshot = async function(url) {
-  console.log('HazardMap.getScreenshot');
+  console.log('HazardMap.getScreenshot', url);
 
   let renderer;
 

--- a/src/reportParts/HazardMap.scss
+++ b/src/reportParts/HazardMap.scss
@@ -1,0 +1,4 @@
+.hazard-map-image {
+  width: 100%;
+  min-height: 200px;
+}

--- a/src/reportParts/Loader.js
+++ b/src/reportParts/Loader.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import './Loader.scss';
+
+
+export default () => {
+  return (
+    <div className="loader-container">
+      <div className="loader">
+        <div></div>
+        <div></div>
+        <div></div>
+      </div>
+    </div>
+  );
+}

--- a/src/reportParts/Loader.scss
+++ b/src/reportParts/Loader.scss
@@ -1,0 +1,47 @@
+@import '../variables';
+
+.loader-container {
+  display: flex;
+  justify-content: center;
+
+  /* code obtained from https://loading.io/css/ */
+  .loader {
+    display: inline-block;
+    position: relative;
+    width: 80px;
+    height: 80px;
+
+    div {
+      display: inline-block;
+      position: absolute;
+      left: 8px;
+      width: 16px;
+      background: $defaultColor;
+      animation: loader 1.2s cubic-bezier(0, 0.5, 0.5, 1) infinite;
+    }
+    div:nth-child(1) {
+      left: 8px;
+      animation-delay: -0.24s;
+    }
+    div:nth-child(2) {
+      left: 32px;
+      animation-delay: -0.12s;
+    }
+    div:nth-child(3) {
+      left: 56px;
+      animation-delay: 0;
+    }
+  }
+}
+
+
+@keyframes loader {
+  0% {
+    top: 8px;
+    height: 64px;
+  }
+  50%, 100% {
+    top: 24px;
+    height: 32px;
+  }
+}

--- a/src/reportParts/ProgressBar.scss
+++ b/src/reportParts/ProgressBar.scss
@@ -1,8 +1,12 @@
 @import '../variables';
 
 .progress {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
   display: flex;
-  height: 1rem;
+  height: 1.5rem;
   overflow: hidden; // force rounded corners by cropping it
   font-size: 1rem * .75;
   background-color: #e9ecef;

--- a/src/reportParts/ProgressBar.scss
+++ b/src/reportParts/ProgressBar.scss
@@ -1,3 +1,5 @@
+@import '../variables';
+
 .progress {
   display: flex;
   height: 1rem;
@@ -15,7 +17,7 @@
     color: #ddd;
     text-align: center;
     white-space: nowrap;
-    background-color: #ff851b;
+    background-color: $defaultColor;
     transition: width .6s ease;
 
     &--striped {

--- a/src/variables.scss
+++ b/src/variables.scss
@@ -1,0 +1,1 @@
+$defaultColor: #ff851b;


### PR DESCRIPTION
This pull request adds a new animated component for showing the user that a specific part of the report is still being generated. For example:
![image](https://user-images.githubusercontent.com/1326248/69887537-ad522600-12a4-11ea-89b6-92ae258286b7.png)

This finishes up and closes #12.

This PR also adds the overview map.