### PR TITLE
QFF Layer and Fixed Map Image Size

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ugs-hazards",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ugs-hazards",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "private": true,
   "homepage": ".",
   "dependencies": {

--- a/public/demo.html
+++ b/public/demo.html
@@ -1,8 +1,74 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+
   <title>Demo</title>
+
+  <link rel="stylesheet" href="https://js.arcgis.com/4.14/esri/themes/light/main.css" />
+  <script src="https://js.arcgis.com/4.14/"></script>
+
+  <style>
+    body {
+      margin: 0;
+    }
+    #viewDiv {
+      height: 500px;
+      width: 100%;
+    }
+    #container {
+      display: flex;
+    }
+    #textArea {
+      flex: 1;
+    }
+    button {
+      width: 200px;
+      font-size: 200%;
+    }
+  </style>
+
   <script type="text/javascript">
+    require([
+      'esri/widgets/Sketch',
+      'esri/Map',
+      'esri/layers/GraphicsLayer',
+      'esri/views/MapView'
+    ], function (Sketch, Map, GraphicsLayer, MapView) {
+      const layer = new GraphicsLayer();
+
+      const map = new Map({
+        basemap: 'streets',
+        layers: [layer]
+      });
+
+      const view = new MapView({
+        container: 'viewDiv',
+        map: map,
+        zoom: 8,
+        center: [-111, 40]
+      });
+
+      const sketch = new Sketch({
+        layer: layer,
+        view: view,
+        availableCreateTools: ['polygon']
+      });
+
+      sketch.on('create', event => {
+        if (event.state === 'complete') {
+          const textArea = document.getElementById('textArea');
+          textArea.value = JSON.stringify({
+            description: 'Hand-drawn Polygon',
+            polygon: event.graphic.geometry.toJSON()
+          }, null, 2);
+        } else if (event.state === 'start') {
+          layer.removeAll();
+        }
+      });
+
+      view.ui.add(sketch, 'top-right');
+    });
+
     window.onClick = () => {
       const textArea = document.getElementById('textArea');
       const testString = textArea.value;
@@ -13,48 +79,53 @@
       localStorage.setItem('aoi', JSON.stringify(testData));
 
       window.open('.');
-    }
+    };
   </script>
 </head>
-<body style="display:flex">
-  <textarea rows="30" id="textArea" style="width:100%">
-    {
-      "description": "Test AOI Description",
-      "polygon": {
-        "rings": [
-          [
+
+<body>
+  <p>Draw a polygon on the map and the geometry is auto-populated in the text area below. Press "Go" to run a report.</p>
+  <div id="viewDiv"></div>
+  <div id="container">
+    <textarea rows="30" id="textArea">
+      {
+        "description": "Test AOI Description",
+        "polygon": {
+          "rings": [
             [
-              -12472025.223916203,
-              4967174.1688544145
-            ],
-            [
-              -12471929.677630847,
-              4967107.2864546655
-            ],
-            [
-              -12471920.123002311,
-              4966696.437427633
-            ],
-            [
-              -12472522.064600056,
-              4966744.210570311
-            ],
-            [
-              -12472464.736828843,
-              4967279.269768307
-            ],
-            [
-              -12472025.223916203,
-              4967174.1688544145
+              [
+                -12472025.223916203,
+                4967174.1688544145
+              ],
+              [
+                -12471929.677630847,
+                4967107.2864546655
+              ],
+              [
+                -12471920.123002311,
+                4966696.437427633
+              ],
+              [
+                -12472522.064600056,
+                4966744.210570311
+              ],
+              [
+                -12472464.736828843,
+                4967279.269768307
+              ],
+              [
+                -12472025.223916203,
+                4967174.1688544145
+              ]
             ]
-          ]
-        ],
-        "spatialReference": {
-          "wkid": 3857
+          ],
+          "spatialReference": {
+            "wkid": 3857
+          }
         }
       }
-    }
-  </textarea>
-  <button onclick='onClick()' style="width:200px;font-size:200%;">Go</button>
+    </textarea>
+    <button onclick='onClick()'>Go</button>
+  </div>
 </body>
 </html>

--- a/src/App.js
+++ b/src/App.js
@@ -173,40 +173,42 @@ export default props => {
           <button onClick={window.print}>Print Report</button>
         </div>
       </ProgressBar>
-      <HazardMap aoi={props.polygon} queriesWithResults={queriesWithResults}>
-        <CoverPage aoiDescription={props.description} {...reportTextMap} />
-        <SummaryPage {...reportTextMap}
-          hazardToUnitMap={hazardToUnitMap}
-          aerialFeatures={aerialFeatures}
-          lidarFeatures={lidarFeatures}
-          groupToHazardMap={groupToHazardMap} />
-        {Object.keys(groupToHazardMap).map(groupName => (
-          <Group key={groupName} name={groupName} text={groupToTextMap[groupName]}>
-            {hazardIntroText && hazardReferences && hazardToUnitMap && groupToHazardMap[groupName].map(hazardCode => {
-              const intro = hazardIntroText.filter(x => x.Hazard === hazardCode)[0];
-              const introText = (intro) ? intro.Text : null;
-              const references = hazardReferences.filter(x => x.Hazard === hazardCode);
-              const units = hazardToUnitMap[hazardCode];
-                  return (
-                    <Hazard name={units[0].HazardName} group={groupName} introText={introText} key={hazardCode} code={hazardCode}>
-                      { units.map((unit, index) => <HazardUnit key={index} {...unit}/>) }
-                      <References references={references.map(({ Text }) => Text)}></References>
-                    </Hazard>
-                  )
-                })}
-          </Group>
-        ))}
-        <OtherDataPage {...otherDataMap['Lidar Elevation Data']} mapKey={config.mapKeys.lidar} id="lidar">
-          {lidarFeatures.map((feature, index) => <LidarFeature key={index} {...feature} />)}
-        </OtherDataPage>
-        <OtherDataPage {...otherDataMap['Aerial Photography and Imagery']} mapKey={config.mapKeys.aerials} id="aerial-photography">
-          {aerialFeatures.map((feature, index) => <AerialFeature key={index} {...feature} />)}
-        </OtherDataPage>
-      </HazardMap>
-      <div className="header page-break">
-        <h1>OTHER GEOLOGIC HAZARD RESOURCES</h1>
-        <p dangerouslySetInnerHTML={{__html: reportTextMap.OtherGeologicHazardResources}}
-          title={config.notProd && 'ReportTextTable.Text(OtherGeologicHazardResources)'}></p>
+      <div className="app--container">
+        <HazardMap aoi={props.polygon} queriesWithResults={queriesWithResults}>
+          <CoverPage aoiDescription={props.description} {...reportTextMap} />
+          <SummaryPage {...reportTextMap}
+            hazardToUnitMap={hazardToUnitMap}
+            aerialFeatures={aerialFeatures}
+            lidarFeatures={lidarFeatures}
+            groupToHazardMap={groupToHazardMap} />
+          {Object.keys(groupToHazardMap).map(groupName => (
+            <Group key={groupName} name={groupName} text={groupToTextMap[groupName]}>
+              {hazardIntroText && hazardReferences && hazardToUnitMap && groupToHazardMap[groupName].map(hazardCode => {
+                const intro = hazardIntroText.filter(x => x.Hazard === hazardCode)[0];
+                const introText = (intro) ? intro.Text : null;
+                const references = hazardReferences.filter(x => x.Hazard === hazardCode);
+                const units = hazardToUnitMap[hazardCode];
+                    return (
+                      <Hazard name={units[0].HazardName} group={groupName} introText={introText} key={hazardCode} code={hazardCode}>
+                        { units.map((unit, index) => <HazardUnit key={index} {...unit}/>) }
+                        <References references={references.map(({ Text }) => Text)}></References>
+                      </Hazard>
+                    )
+                  })}
+            </Group>
+          ))}
+          <OtherDataPage {...otherDataMap['Lidar Elevation Data']} mapKey={config.mapKeys.lidar} id="lidar">
+            {lidarFeatures.map((feature, index) => <LidarFeature key={index} {...feature} />)}
+          </OtherDataPage>
+          <OtherDataPage {...otherDataMap['Aerial Photography and Imagery']} mapKey={config.mapKeys.aerials} id="aerial-photography">
+            {aerialFeatures.map((feature, index) => <AerialFeature key={index} {...feature} />)}
+          </OtherDataPage>
+        </HazardMap>
+        <div className="header page-break">
+          <h1>OTHER GEOLOGIC HAZARD RESOURCES</h1>
+          <p dangerouslySetInnerHTML={{__html: reportTextMap.OtherGeologicHazardResources}}
+            title={config.notProd && 'ReportTextTable.Text(OtherGeologicHazardResources)'}></p>
+        </div>
       </div>
       </ProgressContext.Provider>
   </> : <ErrorPage error={pageError} />);

--- a/src/App.scss
+++ b/src/App.scss
@@ -1,11 +1,20 @@
-body {
+@import './variables';
+
+#root {
   font-size: 11pt;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }
 
 .header {
   display: flex;
   flex-direction: column;
   align-items: center;
+}
+
+.app--container {
+  width: $mapScreenWidth;
 }
 
 .page-break {

--- a/src/config.js
+++ b/src/config.js
@@ -44,7 +44,7 @@ export default {
     ['Utah_Geologic_Hazards/FeatureServer/17', 'SBP'], // Shallow Bedrock Potential
     ['Utah_Geologic_Hazards/FeatureServer/18', 'SLS'], // Soluble Soil and Rock Susceptibility
     ['Utah_Geologic_Hazards/FeatureServer/19', 'WSS'], // Wind-Blown Sand Susceptibility
-    ['Utah_Earthquake_Hazards/FeatureServer/2', 'QFF'], // Quaternary Faults
+    ['https://webmaps.geology.utah.gov/arcgis/rest/services/Hazards/quaternary_faults/MapServer/0', 'QFF'], // Quaternary Faults
     ['Utah_Earthquake_Hazards/FeatureServer/3', 'LQS'], // Liquefaction Susceptibility
     ['Utah_Earthquake_Hazards/FeatureServer/4', 'SFR'], // Surface Fault Rupture Hazard Special Study Zone
     ['Utah_Earthquake_Hazards/FeatureServer/6', groundshakingHazardCode] // Groundshaking Polygons
@@ -52,7 +52,7 @@ export default {
   webMaps: {
     hazard: (process.env.REACT_APP_ENVIRONMENT === 'dev') ?
       // development
-      '75f96478838e4cc8a5360ff55304520b' :
+      '13b439cd4af94e5e93e47e405d463514' :
       // production & staging
       'a2d16377b4b5495ab2aaca8dd14463ba'
   }

--- a/src/reportParts/HazardMap.js
+++ b/src/reportParts/HazardMap.js
@@ -3,6 +3,7 @@ import config from '../config';
 import getModules from '../esriModules';
 import { ProgressContext } from '../App';
 import { getLayerInfo } from '../services/QueryService';
+import './HazardMap.scss';
 
 
 export const HazardMapContext = createContext({
@@ -29,7 +30,6 @@ export default props => {
     const { WebMap, MapView, Polygon, Graphic, ScaleBar } = await getModules();
 
     const mapDiv = document.createElement('div');
-    mapDiv.style = 'position: absolute; left: -5000px; width: 1000px; height: 500px';
     document.body.appendChild(mapDiv);
 
     const polylineSymbol = {
@@ -196,7 +196,9 @@ const getScreenshot = async function(url, hazardCode) {
 
   await watchUtils.whenFalseOnce(view, 'updating');
 
-  const screenshot = await view.takeScreenshot({width: 2550, height: 1576});
+  // map width is 8.5" - 0.78" (default print margins for Chrome on macOS) * 300 dpi
+  // height is golden ratio
+  const screenshot = await view.takeScreenshot({width: 2316, height: 1431});
   // cache scale bar dom since it could be different for different maps
   const scaleBarDom = scaleBar.container.cloneNode(true);
   const scale = view.scale;

--- a/src/reportParts/HazardMap.scss
+++ b/src/reportParts/HazardMap.scss
@@ -1,0 +1,8 @@
+@import '../variables';
+
+.esri-view {
+  width: $mapScreenWidth;
+  height: $mapScreenHeight;
+  position: absolute;
+  left: -5000px;
+}

--- a/src/reportParts/HazardUnit.js
+++ b/src/reportParts/HazardUnit.js
@@ -18,7 +18,7 @@ export default props => {
       const { symbolUtils } = await getModules();
       let renderers = [];
 
-      if (renderer.type === 'unique-value') {
+      if (renderer.type === 'unique-value' || renderer.type === 'uniqueValue') {
         renderers = renderer.uniqueValueInfos.filter(info => info.value === props.HazardUnit);
       }
 
@@ -37,7 +37,7 @@ export default props => {
 
     console.log('mapContext', mapContext);
     const assets = mapContext.visualAssets[getHazardCodeFromUnitCode(props.HazardUnit)];
-    if (!hasLegend && assets) {
+    if (!hasLegend && assets && assets.renderer) {
       buildLegend(assets.renderer);
     }
   }, [hasLegend, props.HazardUnit, mapContext]);

--- a/src/reportParts/MapSurround.scss
+++ b/src/reportParts/MapSurround.scss
@@ -14,8 +14,8 @@ $borderWidth: 2px;
     font-size: 12px;
   }
   &__image {
-    width: calc(100% - #{$borderWidth} * 2);
-    min-height: 200px;
+    width: $mapScreenWidth;
+    height: $mapScreenHeight;
     border: $borderWidth solid $gray;
   }
 }

--- a/src/services/QueryService.js
+++ b/src/services/QueryService.js
@@ -156,9 +156,10 @@ export const queryAerialAsync = async aoi => {
 
   const features = await retryPolicy(`${config.urls.aerialImageryCenterPoints}/query?${stringify(parameters)}`,
     (responseJson) => responseJson.features.map(feature => feature.attributes));
+  const agencies = Array.from(new Set(features.map(feature => feature.Agency)));
 
   // mix in agency descriptions from related table
-  const agenciesWhere = `Agency IN ('${features.map(feature => feature.Agency).join(',')}')`;
+  const agenciesWhere = `Agency IN ('${agencies.join(',')}')`;
   const tableResults = await queryTable(config.urls.imageAgenciesTable, agenciesWhere, ['Agency', 'Description']);
   const descriptionsLookup = {};
   tableResults.forEach(result => {

--- a/src/services/QueryService.js
+++ b/src/services/QueryService.js
@@ -3,7 +3,7 @@ import { stringify } from 'query-string';
 import { getHazardCodeFromUnitCode } from '../helpers';
 import polly from 'polly-js';
 
-const retryPolicy = (url, outputFormatter) => {
+const retryPolicy = (url, outputFormatter=response => response) => {
   return polly().waitAndRetry(3).executeForPromise(async () => {
     const response = await fetch(url);
 
@@ -30,7 +30,11 @@ const retryPolicy = (url, outputFormatter) => {
 export const queryUnitsAsync = async (meta, aoi) => {
   console.log('QueryService.queryUnitsAsync');
 
-  const [url, hazard] = meta;
+  let [url, hazard] = meta;
+
+  if (!url.startsWith('https')) {
+    url = `${config.urls.baseUrl}/${url}`;
+  }
 
   const hazardField = `${hazard}HazardUnit`;
 
@@ -42,7 +46,7 @@ export const queryUnitsAsync = async (meta, aoi) => {
     f: 'json'
   };
 
-  return await retryPolicy(`${config.urls.baseUrl}/${url}/query?${stringify(parameters)}`, (responseJson) => {
+  return await retryPolicy(`${url}/query?${stringify(parameters)}`, (responseJson) => {
     return {
       units: responseJson.features.map(feature => feature.attributes[hazardField]),
         hazard,
@@ -172,4 +176,10 @@ export const queryAerialAsync = async aoi => {
       Description: descriptionsLookup[feature.Agency]
     }
   });
+};
+
+export const getLayerInfo = async url => {
+  const info = await retryPolicy(`${url}?f=json`);
+
+  return info;
 };

--- a/src/variables.scss
+++ b/src/variables.scss
@@ -1,2 +1,6 @@
 $defaultColor: #ff851b;
 $gray: #666;
+
+/* 8.5 - 0.78" * 96 dpi */
+$mapScreenWidth: 741px;
+$mapScreenHeight: 458px;


### PR DESCRIPTION
The PR makes attempts to close #41 (switch to map image layer for QFF) & #46 (fixed map widths).

For #41, it turned into a bit of a mess. I wonder if we should just tell them that it's not going to work with map image layers. I did get it close but had to add a lot of exception code around the map image layer that feels pretty hacky. The legends still don't work. I'm pretty sure that it's because they are symbolizing on a field that we aren't expecting.

https://github.com/agrc/ugs-hazards/commit/4af57c65f7005d35d3d39a7253a8e4354a758eab was a bug that I found when I drew an AOI that contained a lot of aerial imagery points.

I also added a map with sketch tools to the demo page to allow for drawing AOIs rather than having to get the JSON code from somewhere else and copy/paste.

For #46, I think that the scales are now pretty close to correct. Here was my sanity check:
![image](https://user-images.githubusercontent.com/1326248/71421587-14ab8d80-2639-11ea-8617-aae7a25d0275.png)

I've pushed this to test so that people that check it out.