### PR TITLE
Added flex-wrap property

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -3,6 +3,7 @@
 #root {
   font-size: 11pt;
   display: flex;
+  flex_wrap: wrap;
   flex-direction: column;
   align-items: center;
 }

--- a/src/App.scss
+++ b/src/App.scss
@@ -3,7 +3,7 @@
 #root {
   font-size: 11pt;
   display: flex;
-  flex_wrap: wrap;
+  flex-wrap: wrap;
   flex-direction: column;
   align-items: center;
 }


### PR DESCRIPTION
When viewing a report on mobile I am unable to zoom out or pan to the left to view the left most part of the text, I think adding this property to the root div will fix it.